### PR TITLE
Adding a getException method to ApiProblem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-eventmanager": ">=2.2.0",
+        "zendframework/zend-eventmanager": ">=2.2.0,<3.0.0",
         "zendframework/zend-json": ">=2.2.0",
         "zendframework/zend-loader": ">=2.2.0",
-        "zendframework/zend-mvc": ">=2.2.0",
+        "zendframework/zend-mvc": ">=2.2.0,<3.0.0",
         "zendframework/zend-paginator": ">=2.2.0",
         "zendframework/zend-uri": ">=2.2.0",
         "zendframework/zend-view": ">=2.2.0",
@@ -39,7 +39,7 @@
         "zendframework/zend-console": ">=2.2.0",
         "zendframework/zend-http": ">=2.2.0",
         "zendframework/zend-navigation": ">=2.2.0",
-        "zendframework/zend-servicemanager": ">=2.2.0"
+        "zendframework/zend-servicemanager": ">=2.2.0,<3.0.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/PhlyRestfully/ApiProblem.php
+++ b/src/PhlyRestfully/ApiProblem.php
@@ -180,6 +180,18 @@ class ApiProblem
     }
 
     /**
+     * Get passed in exception if available
+     *
+     * @return \Exception
+     */
+    public function getException()
+    {
+        if ($this->detail instanceof \Exception) {
+            return $this->detail;
+        }
+    }
+
+    /**
      * Cast to an array
      *
      * @return array

--- a/src/PhlyRestfully/Listener/ApiProblemListener.php
+++ b/src/PhlyRestfully/Listener/ApiProblemListener.php
@@ -55,7 +55,7 @@ class ApiProblemListener implements ListenerAggregateInterface
     /**
      * @param EventManagerInterface $events
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, __CLASS__ . '::onRender', 1000);
     }

--- a/src/PhlyRestfully/Listener/ResourceParametersListener.php
+++ b/src/PhlyRestfully/Listener/ResourceParametersListener.php
@@ -32,7 +32,7 @@ class ResourceParametersListener implements
     /**
      * @param EventManagerInterface $events
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach('dispatch', array($this, 'onDispatch'), 100);
     }

--- a/src/PhlyRestfully/Plugin/HalLinks.php
+++ b/src/PhlyRestfully/Plugin/HalLinks.php
@@ -26,7 +26,7 @@ use Zend\Paginator\Paginator;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\DispatchableInterface;
 use Zend\Hydrator\HydratorInterface;
-use Zend\Stdlib\Hydrator\HydratorPluginManager;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\View\Helper\AbstractHelper;
 use Zend\View\Helper\ServerUrl;
 use Zend\View\Helper\Url;

--- a/test/PhlyRestfullyTest/ApiProblemTest.php
+++ b/test/PhlyRestfullyTest/ApiProblemTest.php
@@ -194,4 +194,19 @@ class ApiProblemTest extends TestCase
         $this->assertArrayHasKey('foo', $payload);
         $this->assertEquals('bar', $payload['foo']);
     }
+
+    public function testGetExceptionReturnsExceptionIfPassedInAsDetail()
+    {
+        $exception  = new Exception\CreationException('exception message', 401);
+        $apiProblem = new ApiProblem('401', $exception);
+
+        $this->assertTrue($apiProblem->getException() instanceof Exception\CreationException);
+    }
+
+    public function testGetExceptionReturnsNullIfStringPassedInAsDetail()
+    {
+        $apiProblem = new ApiProblem('401', 'Bad error happened');
+
+        $this->assertNull($apiProblem->getException());
+    }
 }

--- a/test/PhlyRestfullyTest/CollectionIntegrationTest.php
+++ b/test/PhlyRestfullyTest/CollectionIntegrationTest.php
@@ -220,7 +220,7 @@ class CollectionIntegrationTest extends TestCase
 
     public function getServiceManager()
     {
-        $controllers = new ControllerManager();
+        $controllers = new ControllerManager(null);
         $controllers->addAbstractFactory('PhlyRestfully\Factory\ResourceControllerFactory');
 
         $services    = new ServiceManager();

--- a/test/PhlyRestfullyTest/Factory/ResourceControllerFactoryTest.php
+++ b/test/PhlyRestfullyTest/Factory/ResourceControllerFactoryTest.php
@@ -18,7 +18,7 @@ class ResourceControllerFactoryTest extends TestCase
     public function setUp()
     {
         $this->services    = $services    = new ServiceManager();
-        $this->controllers = $controllers = new ControllerManager();
+        $this->controllers = $controllers = new ControllerManager(null);
         $this->factory     = $factory     = new ResourceControllerFactory();
 
         $controllers->addAbstractFactory($factory);


### PR DESCRIPTION
Wanted to be able to expose the exception if passed in, so it can be
retrieved and later passed to something else (when all we have is the
ApiProblem object).

Had to update some dependencies and signatures/namespaces to make
compatible with updated versions of other ZF libraries.