### PR TITLE
Changes to support newer PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
-        "phpunit/PHPUnit": "^5.7.11",
+        "phpunit/PHPUnit": "^5.7.11 || ^6.0 || ^7.0",
         "vimeo/psalm": "1.1.4",
         "zendframework/zend-console": "^2.5",
         "zendframework/zend-http": "^2.5",

--- a/test/ApiProblemTest.php
+++ b/test/ApiProblemTest.php
@@ -10,7 +10,7 @@ namespace PhlyRestfullyTest;
 
 use PhlyRestfully\ApiProblem;
 use PhlyRestfully\Exception;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
 
 class ApiProblemTest extends TestCase

--- a/test/ChildResourcesIntegrationTest.php
+++ b/test/ChildResourcesIntegrationTest.php
@@ -16,7 +16,7 @@ use PhlyRestfully\Resource;
 use PhlyRestfully\ResourceController;
 use PhlyRestfully\View\RestfulJsonModel;
 use PhlyRestfully\View\RestfulJsonRenderer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
 use Zend\Http\Request;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;

--- a/test/CollectionIntegrationTest.php
+++ b/test/CollectionIntegrationTest.php
@@ -14,7 +14,7 @@ use PhlyRestfully\Resource;
 use PhlyRestfully\ResourceController;
 use PhlyRestfully\View\RestfulJsonModel;
 use PhlyRestfully\View\RestfulJsonRenderer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\EventManager\SharedEventManager;
 use Zend\Http\PhpEnvironment\Request;
 use Zend\Http\PhpEnvironment\Response;

--- a/test/Factory/ResourceControllerFactoryTest.php
+++ b/test/Factory/ResourceControllerFactoryTest.php
@@ -10,7 +10,7 @@ namespace PhlyRestfullyTest\Factory;
 
 use PhlyRestfully\ResourceController;
 use PhlyRestfully\Factory\ResourceControllerFactory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
 use Zend\Mvc\Controller\ControllerManager;

--- a/test/HalCollectionTest.php
+++ b/test/HalCollectionTest.php
@@ -12,7 +12,7 @@ use PhlyRestfully\Exception;
 use PhlyRestfully\HalCollection;
 use PhlyRestfully\Link;
 use PhlyRestfully\LinkCollection;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use stdClass;
 
 class HalCollectionTest extends TestCase
@@ -37,7 +37,7 @@ class HalCollectionTest extends TestCase
      */
     public function testConstructorRaisesExceptionForNonTraversableCollection($collection)
     {
-        $this->setExpectedException(Exception\InvalidCollectionException::class);
+        $this->expectException(Exception\InvalidCollectionException::class);
         $hal = new HalCollection($collection, 'collection/route', 'item/route');
     }
 

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -11,7 +11,7 @@ namespace PhlyRestfullyTest;
 use PhlyRestfully\Exception;
 use PhlyRestfully\HalResource;
 use PhlyRestfully\LinkCollection;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use stdClass;
 
 class HalResourceTest extends TestCase
@@ -35,7 +35,7 @@ class HalResourceTest extends TestCase
      */
     public function testConstructorRaisesExceptionForNonObjectNonArrayResource($resource)
     {
-        $this->setExpectedException(Exception\InvalidResourceException::class);
+        $this->expectException(Exception\InvalidResourceException::class);
         $hal = new HalResource($resource, 'id');
     }
 

--- a/test/LinkCollectionTest.php
+++ b/test/LinkCollectionTest.php
@@ -10,7 +10,7 @@ namespace PhlyRestfullyTest;
 
 use PhlyRestfully\Link;
 use PhlyRestfully\LinkCollection;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class LinkCollectionTest extends TestCase
 {

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -10,7 +10,7 @@ namespace PhlyRestfullyTest;
 
 use PhlyRestfully\Exception;
 use PhlyRestfully\Link;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class LinkTest extends TestCase
 {
@@ -83,7 +83,7 @@ class LinkTest extends TestCase
         $link = new Link('describedby');
         $link->setRoute('api/docs');
 
-        $this->setExpectedException(Exception\DomainException::class);
+        $this->expectException(Exception\DomainException::class);
         $link->setUrl('http://example.com/api/docs.html');
     }
 
@@ -92,7 +92,7 @@ class LinkTest extends TestCase
         $link = new Link('describedby');
         $link->setUrl('http://example.com/api/docs.html');
 
-        $this->setExpectedException(Exception\DomainException::class);
+        $this->expectException(Exception\DomainException::class);
         $link->setRoute('api/docs');
     }
 

--- a/test/Listener/ApiProblemListenerTest.php
+++ b/test/Listener/ApiProblemListenerTest.php
@@ -9,7 +9,7 @@
 namespace PhlyRestfullyTest\Listener;
 
 use PhlyRestfully\Listener\ApiProblemListener;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\Console\Request as ConsoleRequest;
 use Zend\Console\Response as ConsoleResponse;
 use Zend\Mvc\MvcEvent;

--- a/test/Listener/ResourceParametersListenerTest.php
+++ b/test/Listener/ResourceParametersListenerTest.php
@@ -11,7 +11,7 @@ namespace PhlyRestfullyTest\Listener;
 use PhlyRestfully\Listener\ResourceParametersListener;
 use PhlyRestfully\Resource;
 use PhlyRestfully\ResourceController;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\Http\PhpEnvironment\Request;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -9,7 +9,7 @@
 namespace PhlyRestfullyTest;
 
 use PhlyRestfully\Module;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
 use Zend\Hydrator;
 use Zend\Mvc\Application;

--- a/test/Plugin/HalLinksTest.php
+++ b/test/Plugin/HalLinksTest.php
@@ -14,7 +14,7 @@ use PhlyRestfully\Link;
 use PhlyRestfully\MetadataMap;
 use PhlyRestfully\Plugin\HalLinks;
 use PhlyRestfully\ResourceController;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\Http\Request;
 use Zend\Hydrator;
 use Zend\Mvc\Router\Http\TreeRouteStack;

--- a/test/ResourceControllerTest.php
+++ b/test/ResourceControllerTest.php
@@ -16,7 +16,7 @@ use PhlyRestfully\Plugin;
 use PhlyRestfully\Resource;
 use PhlyRestfully\ResourceController;
 use PhlyRestfully\View\RestfulJsonModel;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
 use stdClass;
 use Zend\EventManager\EventManager;
@@ -442,7 +442,7 @@ class ResourceControllerTest extends TestCase
     public function testOnDispatchRaisesDomainExceptionOnMissingResource()
     {
         $controller = new ResourceController();
-        $this->setExpectedException(Exception\DomainException::class, 'ResourceInterface');
+        $this->expectException(Exception\DomainException::class, 'ResourceInterface');
         $controller->onDispatch($this->event);
     }
 
@@ -450,7 +450,7 @@ class ResourceControllerTest extends TestCase
     {
         $controller = new ResourceController();
         $controller->setResource($this->resource);
-        $this->setExpectedException(Exception\DomainException::class, 'route');
+        $this->expectException(Exception\DomainException::class, 'route');
         $controller->onDispatch($this->event);
     }
 

--- a/test/ResourceEventTest.php
+++ b/test/ResourceEventTest.php
@@ -9,7 +9,7 @@
 namespace PhlyRestfullyTest;
 
 use PhlyRestfully\ResourceEvent;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Stdlib\Parameters;
 

--- a/test/ResourceTest.php
+++ b/test/ResourceTest.php
@@ -14,7 +14,7 @@ use PhlyRestfully\Exception;
 use PhlyRestfully\Resource;
 use PhlyRestfully\ResourceEvent;
 use PhlyRestfully\ResourceInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use stdClass;
 use Zend\EventManager\EventManager;
 use Zend\Mvc\Router\RouteMatch;
@@ -70,7 +70,7 @@ class ResourceTest extends TestCase
      */
     public function testCreateRaisesExceptionWithInvalidData($data)
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->resource->create($data);
     }
 
@@ -133,7 +133,7 @@ class ResourceTest extends TestCase
      */
     public function testPatchListListRaisesExceptionWithInvalidData($data)
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->resource->patchList($data);
     }
 
@@ -171,7 +171,7 @@ class ResourceTest extends TestCase
      */
     public function testUpdateRaisesExceptionWithInvalidData($data)
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->resource->update('foo', $data);
     }
 
@@ -209,7 +209,7 @@ class ResourceTest extends TestCase
      */
     public function testReplaceListRaisesExceptionWithInvalidData($data)
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->resource->replaceList($data);
     }
 
@@ -247,7 +247,7 @@ class ResourceTest extends TestCase
      */
     public function testPatchRaisesExceptionWithInvalidData($data)
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->resource->patch('foo', $data);
     }
 
@@ -322,7 +322,7 @@ class ResourceTest extends TestCase
      */
     public function testDeleteListRaisesInvalidArgumentExceptionForInvalidData($data)
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class, '::deleteList');
+        $this->expectException(Exception\InvalidArgumentException::class, '::deleteList');
         $this->resource->deleteList($data);
     }
 

--- a/test/View/RestfulJsonModelTest.php
+++ b/test/View/RestfulJsonModelTest.php
@@ -12,7 +12,7 @@ use PhlyRestfully\ApiProblem;
 use PhlyRestfully\HalCollection;
 use PhlyRestfully\HalResource;
 use PhlyRestfully\View\RestfulJsonModel;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use stdClass;
 
 /**

--- a/test/View/RestfulJsonRendererTest.php
+++ b/test/View/RestfulJsonRendererTest.php
@@ -17,7 +17,7 @@ use PhlyRestfully\Plugin\HalLinks;
 use PhlyRestfully\View\RestfulJsonModel;
 use PhlyRestfully\View\RestfulJsonRenderer;
 use PhlyRestfullyTest\TestAsset;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
 use Zend\Mvc\Router\Http\Segment;
 use Zend\Mvc\Router\Http\TreeRouteStack;

--- a/test/View/RestfulJsonStrategyTest.php
+++ b/test/View/RestfulJsonStrategyTest.php
@@ -15,7 +15,7 @@ use PhlyRestfully\Link;
 use PhlyRestfully\View\RestfulJsonModel;
 use PhlyRestfully\View\RestfulJsonRenderer;
 use PhlyRestfully\View\RestfulJsonStrategy;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Zend\Http\Response;
 use Zend\View\Renderer\JsonRenderer;
 use Zend\View\ViewEvent;


### PR DESCRIPTION
We've been getting some PR's from dependabot that are trying to upgrade PHPUnit version, however, the tests classes in this lib use `PHPUnit_Framework_TestCase` and `setExpectedException` which aren't available in newer versions of PHPUnit (so the PRs fail building on Travis), so I'm removing those in place of the newer replacements.  Because we're still supporting PHP 5.6, we need to keep PHPUnit 5.x (but it has the "ForwardCompatibility" classes so the namespaced version of `TestCase` works there as well).

I tested with `--prefer-lowest` (pulls PHPUnit 5.7.11) and without (pulls PHPUnit 7.3.5) and tests passed on my local machine (PHP 7.2). Will see how Travis does.