### PR TITLE
PHP 7.3 Compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: Dependabot Auto Approve
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  auto_approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "hmarr/auto-approve-action@v2.0.0"
+        if: github.actor == 'dependabot-preview[bot]' || github.actor == 'dependabot[bot]'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.php_cs
+++ b/.php_cs
@@ -9,8 +9,11 @@ $finder = PhpCsFixer\Finder::create()
 return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
+        '@PHPUnit60Migration:risky' => true,
+        '@PHPUnit75Migration:risky' => true,
         'no_whitespace_in_blank_line' => true,
         'array_syntax' => ['syntax' => 'short'],
     ])
+    ->setRiskyAllowed(true)
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 env:
   global:
     - COMPOSER_ARGS=""
+    - COMPOSER_DISCARD_CHANGES=1
 
 stages:
   - coding style
@@ -32,18 +33,18 @@ jobs:
   allow_failures:
     - php: nightly
   include:
-    - php: 5.6
-      env: COMPOSER_ARGS="--prefer-lowest"
-    - php: 5.6
-    - php: 7
-      env: COMPOSER_ARGS="--prefer-lowest"
-    - php: 7
     - php: 7.1
       env: COMPOSER_ARGS="--prefer-lowest"
     - php: 7.1
     - php: 7.2
       env: COMPOSER_ARGS="--prefer-lowest"
     - php: 7.2
+    - php: 7.3
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.3
+    - php: 7.4
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.4
     - php: nightly
       env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
     - php: nightly
@@ -51,16 +52,13 @@ jobs:
 
     - stage: coding style
       php: 7.2
-      script: php -n -d memory_limit=768M ./vendor/bin/php-cs-fixer fix --dry-run -vv
+      script: ./vendor/bin/php-cs-fixer fix --dry-run -vv
 
     - stage: static code analysis
       php: 7.2
-      install:
-        - travis_retry composer update --no-interaction --prefer-stable $COMPOSER_ARGS
-        - travis_retry composer require phpstan/phpstan-shim:0.9.2
       script:
-        - vendor/bin/phpstan analyse -l 7 -c phpstan.neon --autoload-file=vendor/autoload.php --memory-limit=768M --no-progress src
-        - vendor/bin/psalm --show-info=false
+        - composer phpstan
+        - composer psalm
 
     - stage: test with coverage
       php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-uri": "^2.5.0",
         "zendframework/zend-view": "^2.7.0",
         "zendframework/zend-stdlib": "^3.2.1",
-        "zendframework/zend-hydrator": "^1.1"
+        "zendframework/zend-hydrator": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.1",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.1",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5.15",
         "vimeo/psalm": "3.8.1",
         "zendframework/zend-console": "^2.5",
         "zendframework/zend-http": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.1",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.5",
         "vimeo/psalm": "3.8.1",
         "zendframework/zend-console": "^2.5",
         "zendframework/zend-http": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "zendframework/zend-paginator": "^2.5.0",
         "zendframework/zend-uri": "^2.5.0",
         "zendframework/zend-view": "^2.7.0",
-        "zendframework/zend-stdlib": "^3.0",
+        "zendframework/zend-stdlib": "^3.2.1",
         "zendframework/zend-hydrator": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "zendframework/zend-console": "^2.5",
         "zendframework/zend-http": "^2.5",
         "zendframework/zend-navigation": "^2.5",
-        "zendframework/zend-servicemanager": "^2.5",
+        "zendframework/zend-servicemanager": "^3.0",
         "phpstan/phpstan": "0.12.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-mvc": "^2.7.13",
         "zendframework/zend-paginator": "^2.5.0",
         "zendframework/zend-uri": "^2.5.0",
-        "zendframework/zend-view": "^2.11.0",
+        "zendframework/zend-view": "^2.11.4",
         "zendframework/zend-stdlib": "^3.2.1",
         "zendframework/zend-hydrator": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
     ],
     "require": {
         "php": ">=5.6",
-        "zendframework/zend-eventmanager": "^2.6",
+        "zendframework/zend-eventmanager": "^3.0",
         "zendframework/zend-json": "^2.5.0|^3.0.0",
         "zendframework/zend-loader": "^2.5.0",
         "zendframework/zend-mvc": "^2.7.13",
         "zendframework/zend-paginator": "^2.5.0",
         "zendframework/zend-uri": "^2.5.0",
         "zendframework/zend-view": "^2.7.0",
-        "zendframework/zend-stdlib": "^2.5.0",
+        "zendframework/zend-stdlib": "^3.0",
         "zendframework/zend-hydrator": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-uri": "^2.5.0",
         "zendframework/zend-view": "^2.11.4",
         "zendframework/zend-stdlib": "^3.2.1",
-        "zendframework/zend-hydrator": "^2.2.3"
+        "zendframework/zend-hydrator": "^2.4.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-mvc": "^2.7.13",
         "zendframework/zend-paginator": "^2.5.0",
         "zendframework/zend-uri": "^2.5.0",
-        "zendframework/zend-view": "^2.7.0",
+        "zendframework/zend-view": "^2.11.0",
         "zendframework/zend-stdlib": "^3.2.1",
         "zendframework/zend-hydrator": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-uri": "^2.5.0",
         "zendframework/zend-view": "^2.11.4",
         "zendframework/zend-stdlib": "^3.2.1",
-        "zendframework/zend-hydrator": "^2.0"
+        "zendframework/zend-hydrator": "^2.2.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.1",

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,14 @@
         "zendframework/zend-hydrator": "^1.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.10",
-        "phpunit/PHPUnit": "^5.7.11 || ^6.0 || ^7.0",
-        "vimeo/psalm": "1.1.4",
+        "friendsofphp/php-cs-fixer": "2.16.1",
+        "phpunit/phpunit": "^7.0",
+        "vimeo/psalm": "3.8.1",
         "zendframework/zend-console": "^2.5",
         "zendframework/zend-http": "^2.5",
         "zendframework/zend-navigation": "^2.5",
-        "zendframework/zend-servicemanager": "^2.5"
+        "zendframework/zend-servicemanager": "^2.5",
+        "phpstan/phpstan": "0.12.3"
     },
     "suggest": {
         "zfr/zfr-cors": "zfr/zfr-cors provides CORS support"
@@ -56,5 +57,9 @@
         "psr-4": {
             "PhlyRestfullyTest\\": "test/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.neon --memory-limit=768M --no-progress --ansi",
+        "psalm": "psalm --show-info=false"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,107 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 3
+			path: src/HalCollection.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 5
+			path: src/HalCollection.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/HalResource.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Link.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 2
+			path: src/Link.php
+
+		-
+			message: "#^Parameter \\#1 \\$listener of method Zend\\\\EventManager\\\\SharedEventManagerInterface\\:\\:detach\\(\\) expects callable\\(\\)\\: mixed, 'PhlyRestfully…' given\\.$#"
+			count: 1
+			path: src/Listener/ResourceParametersListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$matches of method PhlyRestfully\\\\ResourceInterface\\:\\:setRouteMatch\\(\\) expects Zend\\\\Mvc\\\\Router\\\\RouteMatch, Zend\\\\Mvc\\\\Router\\\\RouteMatch\\|null given\\.$#"
+			count: 1
+			path: src/Listener/ResourceParametersListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$hydrator of method PhlyRestfully\\\\Plugin\\\\HalLinks\\:\\:setDefaultHydrator\\(\\) expects Zend\\\\Hydrator\\\\HydratorInterface, object given\\.$#"
+			count: 1
+			path: src/Module.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Call to function is_object\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of class PhlyRestfully\\\\HalCollection constructor expects array\\|Traversable, array\\|object given\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of class PhlyRestfully\\\\HalCollection constructor expects array\\|Traversable, object given\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Cannot call method setItemCountPerPage\\(\\) on array\\|Traversable\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Cannot call method setCurrentPageNumber\\(\\) on array\\|Traversable\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\|Traversable given\\.$#"
+			count: 1
+			path: src/Plugin/HalLinks.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Resource.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: src/Resource.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/ResourceController.php
+
+		-
+			message: "#^Return type \\(PhlyRestfully\\\\ApiProblem\\|PhlyRestfully\\\\HalResource\\|Zend\\\\Http\\\\Response\\) of method PhlyRestfully\\\\ResourceController\\:\\:patch\\(\\) should be compatible with return type \\(array\\) of method Zend\\\\Mvc\\\\Controller\\\\AbstractRestfulController\\:\\:patch\\(\\)$#"
+			count: 1
+			path: src/ResourceController.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: src/Listener/ResourceParametersListener.php
 
 		-
-			message: "#^Parameter \\#1 \\$hydrator of method PhlyRestfully\\\\Plugin\\\\HalLinks\\:\\:setDefaultHydrator\\(\\) expects Zend\\\\Hydrator\\\\HydratorInterface, object given\\.$#"
-			count: 1
-			path: src/Module.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/Plugin/HalLinks.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,6 @@ parameters:
     ignoreErrors:
         # Type-o in ZF2's docblock
         - '#Call to method getTypeString\(\) on an unknown class Zend\\Http\\Header\\Accept\\FieldValuePArt\\AcceptFieldValuePart\.#'
-        # I think in this case an array won't be returned
-        - '#Array \(array<Zend\\Stdlib\\CallbackHandler>\) does not accept array\|Zend\\Stdlib\\CallbackHandler\.#'
         # These can probably be fixed if static type-hints are ever added
         - '#Casting to .+ something that.s already .+\.#'
         # This is more of a defensive thing, docblocks only allow specific object type and string
@@ -11,8 +9,6 @@ parameters:
         # Internal code never sets $identifierName to false, but does have a setter with no restrictions
         - '#Strict comparison using !== between false and string will always evaluate to true\.#'
         - '#Strict comparison using === between false and string will always evaluate to false\.#'
-        # This is a version branch, detected earlier
-        - '#Parameter \#2 \$listener of method Zend\\EventManager\\SharedEventManagerInterface::detach\(\) expects Zend\\Stdlib\\CallbackHandler, string given\.#'
         # ZF2 docblocks aren't correct, does accept an array
         - '#Parameter \#1 \$nameOrModel of method Zend\\View\\Renderer\\JsonRenderer::render\(\) expects string\|Zend\\View\\Model\\ModelInterface, array given\.#'
         # There's a check earlier that checks if there's an ApiProblem (which checks if apiProblem is null), so won't be null here

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,23 +1,25 @@
 parameters:
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
+    level: 8
+    paths:
+        - ./src
     ignoreErrors:
         # Type-o in ZF2's docblock
-        - '#Call to method getTypeString\(\) on an unknown class Zend\\Http\\Header\\Accept\\FieldValuePArt\\AcceptFieldValuePart\.#'
-        # These can probably be fixed if static type-hints are ever added
-        - '#Casting to .+ something that.s already .+\.#'
-        # This is more of a defensive thing, docblocks only allow specific object type and string
-        - '#Call to function is_object\(\) will always evaluate to false\.#'
+        -
+            message: '#Call to method getTypeString\(\) on an unknown class Zend\\Http\\Header\\Accept\\FieldValuePArt\\AcceptFieldValuePart\.#'
+            path: ./src/Listener/ApiProblemListener.php
         # Internal code never sets $identifierName to false, but does have a setter with no restrictions
-        - '#Strict comparison using !== between false and string will always evaluate to true\.#'
-        - '#Strict comparison using === between false and string will always evaluate to false\.#'
+        -
+            message: '#Strict comparison using === between false and string will always evaluate to false\.#'
+            path: ./src/Plugin/HalLinks.php
         # ZF2 docblocks aren't correct, does accept an array
-        - '#Parameter \#1 \$nameOrModel of method Zend\\View\\Renderer\\JsonRenderer::render\(\) expects string\|Zend\\View\\Model\\ModelInterface, array given\.#'
+        -
+            message: '#Parameter \#1 \$nameOrModel of method Zend\\View\\Renderer\\JsonRenderer::render\(\) expects string\|Zend\\View\\Model\\ModelInterface, array given\.#'
+            path: ./src/View/RestfulJsonRenderer.php
         # There's a check earlier that checks if there's an ApiProblem (which checks if apiProblem is null), so won't be null here
-        - '#Parameter \#1 \$problem of method PhlyRestfully\\View\\RestfulJsonStrategy::getStatusCodeFromApiProblem\(\) expects PhlyRestfully\\ApiProblem, PhlyRestfully\\ApiProblem\|null given\.#'
-        # Other issues
-        - '#Parameter \#1 \$collection of class PhlyRestfully\\HalCollection constructor expects array\|Traversable, array\|object given\.#'
-        - '#Call to function count\(\) with argument type array\|Traversable will always result in number 1\.#'
-        - '#Parameter \#1 \$hydrator of method PhlyRestfully\\Plugin\\HalLinks::setDefaultHydrator\(\) expects Zend\\Hydrator\\HydratorInterface, object given\.#'
-        - '#Parameter \#1 \$collection of class PhlyRestfully\\HalCollection constructor expects array\|Traversable, object given\.#'
-        - '#Cannot call method setItemCountPerPage\(\) on array\|Traversable\.#'
-        - '#Cannot call method setCurrentPageNumber\(\) on array\|Traversable\.#'
-        - '#Parameter \#1 \$matches of method PhlyRestfully\\ResourceInterface::setRouteMatch\(\) expects Zend\\Mvc\\Router\\RouteMatch, Zend\\Mvc\\Router\\RouteMatch\|null given\.#'
+        -
+            message: '#Parameter \#1 \$problem of method PhlyRestfully\\View\\RestfulJsonStrategy::getStatusCodeFromApiProblem\(\) expects PhlyRestfully\\ApiProblem, PhlyRestfully\\ApiProblem\|null given\.#'
+            path: ./src/View/RestfulJsonStrategy.php
+includes:
+    - phpstan-baseline.neon

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.8.1@8e54e3aa060fc490d86d0e2abbf62750516d40fd">
+  <file src="src/ApiProblem.php">
+    <RedundantCondition occurrences="2">
+      <code>null === $this-&gt;title</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>null !== $this-&gt;title</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Exception/DomainException.php">
+    <MissingConstructor occurrences="1">
+      <code>$describedBy</code>
+    </MissingConstructor>
+  </file>
+  <file src="src/Factory/ResourceControllerFactory.php">
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$controllers</code>
+      <code>$controllers</code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="src/HalCollection.php">
+    <DocblockTypeContradiction occurrences="10">
+      <code>gettype($collection)</code>
+      <code>is_array($options)</code>
+      <code>is_array($params)</code>
+      <code>is_int($page)</code>
+      <code>!is_int($page) &amp;&amp; !is_numeric($page)</code>
+      <code>is_int($size)</code>
+      <code>!is_int($size) &amp;&amp; !is_numeric($size)</code>
+      <code>is_array($options)</code>
+      <code>is_array($params)</code>
+      <code>$this-&gt;links instanceof LinkCollection</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$collection</code>
+    </InvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$resourceLinks</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>is_object($collection)</code>
+      <code>is_int($page)</code>
+      <code>is_int($size)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/HalResource.php">
+    <DocblockTypeContradiction occurrences="3">
+      <code>is_array($resource)</code>
+      <code>!is_object($resource) &amp;&amp; !is_array($resource)</code>
+      <code>$this-&gt;links instanceof LinkCollection</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$links</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Link.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_array($options)</code>
+      <code>is_array($params)</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$route</code>
+      <code>$url</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Metadata.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>null === $this-&gt;resourceRoute</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$hydrator</code>
+      <code>$hydrators</code>
+      <code>$resourceRoute</code>
+      <code>$route</code>
+      <code>$url</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="5">
+      <code>null !== $this-&gt;hydrator</code>
+      <code>null !== $this-&gt;route</code>
+      <code>null !== $this-&gt;url</code>
+      <code>null !== $this-&gt;hydrators</code>
+      <code>is_string($hydrator)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/MetadataMap.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>null === $this-&gt;hydrators</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$hydrators</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Plugin/HalLinks.php">
+    <DocblockTypeContradiction occurrences="5">
+      <code>$this-&gt;events</code>
+      <code>$this-&gt;metadataMap instanceof MetadataMap</code>
+      <code>is_object($hydrator)</code>
+      <code>gettype($hydrator)</code>
+      <code>false === $identifierName</code>
+    </DocblockTypeContradiction>
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$resource</code>
+      <code>$eventParams['routeParams']</code>
+      <code>$eventParams['route']</code>
+      <code>$eventParams['routeOptions']</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidMethodCall occurrences="2">
+      <code>setItemCountPerPage</code>
+      <code>setCurrentPageNumber</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>$id</code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>setItemCountPerPage</code>
+      <code>setCurrentPageNumber</code>
+      <code>$halCollection-&gt;collection</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="6">
+      <code>$controller</code>
+      <code>$defaultHydrator</code>
+      <code>$events</code>
+      <code>$metadataMap</code>
+      <code>$serverUrlHelper</code>
+      <code>$urlHelper</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>is_string($hydrator)</code>
+      <code>$hydrator instanceof HydratorInterface</code>
+      <code>$this-&gt;defaultHydrator instanceof HydratorInterface</code>
+      <code>false !== $identifierName</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Resource.php">
+    <DocblockTypeContradiction occurrences="8">
+      <code>$this-&gt;events</code>
+      <code>is_object($data)</code>
+      <code>is_array($data)</code>
+      <code>is_object($data)</code>
+      <code>is_array($data)</code>
+      <code>is_object($value)</code>
+      <code>is_object($data)</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="4">
+      <code>bool|ApiProblem</code>
+      <code>bool|ApiProblem</code>
+      <code>ApiProblem|HalCollection|iterable&lt;array-key|mixed, mixed&gt;</code>
+      <code>$this</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingConstructor occurrences="1">
+      <code>$events</code>
+    </MissingConstructor>
+  </file>
+  <file src="src/ResourceController.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$this-&gt;resource === null</code>
+      <code>$this-&gt;resource</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Response|ApiProblem|HalResource</code>
+    </ImplementedReturnTypeMismatch>
+    <MoreSpecificImplementedParamType occurrences="7">
+      <code>$data</code>
+      <code>$data</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$data</code>
+      <code>$request</code>
+    </MoreSpecificImplementedParamType>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$pageSizeParam</code>
+      <code>$resource</code>
+      <code>$route</code>
+      <code>ResourceController</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/ResourceEvent.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ResourceEvent</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/View/RestfulJsonRenderer.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;helpers instanceof HelperPluginManager</code>
+    </DocblockTypeContradiction>
+    <MissingConstructor occurrences="1">
+      <code>$helpers</code>
+    </MissingConstructor>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,14 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config ./vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="./src" />
+        <ignoreFiles>
+            <directory name="./vendor" />
+        </ignoreFiles>
     </projectFiles>
 
     <issueHandlers>
-        <PropertyNotSetInConstructor errorLevel="info" />
-
         <InvalidCatch>
             <errorLevel type="info">
                 <!-- All of the Zend\Uri exceptions extend InvalidArgumentException and implement this interface, so
@@ -19,14 +21,6 @@
                 <file name="src/Link.php" />
             </errorLevel>
         </InvalidCatch>
-
-        <ReservedWord>
-            <errorLevel type="info">
-                <!-- "resource" is a "soft" reserved word as of PHP 7.0: https://secure.php.net/manual/en/reserved.other-reserved-words.php -->
-                <file name="src/Resource.php" />
-                <file name="src/Factory/ResourceControllerFactory.php" />
-            </errorLevel>
-        </ReservedWord>
 
         <InvalidArgument>
             <errorLevel type="info">
@@ -37,12 +31,6 @@
                 <file name="src/View/RestfulJsonRenderer.php" />
             </errorLevel>
         </InvalidArgument>
-
-        <InvalidPropertyAssignmentValue>
-            <errorLevel type="info">
-                <file name="src/Listener/ResourceParametersListener.php" />
-            </errorLevel>
-        </InvalidPropertyAssignmentValue>
 
         <UndefinedClass>
             <errorLevel type="info">
@@ -63,49 +51,11 @@
             </errorLevel>
         </TypeCoercion>
 
-        <RedundantCondition>
-            <errorLevel type="info">
-                <!-- Can't type-hint this (union type), so this check is done to prevent invalid type coming in -->
-                <file name="src/HalResource.php" />
-                <file name="src/Plugin/HalLinks.php" />
-            </errorLevel>
-        </RedundantCondition>
-
         <PossiblyNullArgument>
             <errorLevel type="info">
                 <!-- this has a check before it that would return false if apiProblem is null -->
                 <file name="src/View/RestfulJsonStrategy.php" />
             </errorLevel>
         </PossiblyNullArgument>
-
-        <MissingConstructor>
-            <errorLevel type="info">
-                <file name="src/View/RestfulJsonRenderer.php" />
-            </errorLevel>
-        </MissingConstructor>
-
-        <PossiblyInvalidMethodCall>
-            <errorLevel type="info">
-                <file name="src/Plugin/HalLinks.php" />
-            </errorLevel>
-        </PossiblyInvalidMethodCall>
-
-        <PossiblyUndefinedMethod>
-            <errorLevel type="info">
-                <file name="src/Plugin/HalLinks.php" />
-            </errorLevel>
-        </PossiblyUndefinedMethod>
-
-        <PossiblyInvalidArgument>
-            <errorLevel type="info">
-                <file name="src/Plugin/HalLinks.php" />
-            </errorLevel>
-        </PossiblyInvalidArgument>
-
-        <MoreSpecificImplementedParamType errorLevel="info" />
-        <ImplementedReturnTypeMismatch errorLevel="info" />
-        <!-- These are all defensive checks since the parameters aren't php type-hinted -->
-        <RedundantConditionGivenDocblockType errorLevel="info" />
-        <DocblockTypeContradiction errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -152,7 +152,9 @@ class ApiProblem
 
         $this->httpStatus = $httpStatus;
         $this->detail     = $detail;
-        $this->title      = $title;
+        if ($title !== null) {
+            $this->title      = $title;
+        }
         if (null !== $describedBy) {
             $this->describedBy = $describedBy;
         }
@@ -197,6 +199,8 @@ class ApiProblem
         if ($this->detail instanceof \Exception) {
             return $this->detail;
         }
+
+        return null;
     }
 
     /**
@@ -330,7 +334,7 @@ class ApiProblem
     {
         if ($this->detail instanceof \Exception) {
             $e = $this->detail;
-            $httpStatus = $e->getCode();
+            $httpStatus = (int) $e->getCode();
             if (!empty($httpStatus)) {
                 return $httpStatus;
             } else {

--- a/src/Exception/ProblemExceptionInterface.php
+++ b/src/Exception/ProblemExceptionInterface.php
@@ -13,7 +13,18 @@ namespace PhlyRestfully\Exception;
  */
 interface ProblemExceptionInterface
 {
+    /**
+     * @return array
+     */
     public function getAdditionalDetails();
+
+    /**
+     * @return string
+     */
     public function getDescribedBy();
+
+    /**
+     * @return string
+     */
     public function getTitle();
 }

--- a/src/Factory/ResourceControllerFactory.php
+++ b/src/Factory/ResourceControllerFactory.php
@@ -115,7 +115,7 @@ class ResourceControllerFactory implements AbstractFactoryInterface
 
         /** @var \Zend\EventManager\EventManager $events */
         $events = $services->get('EventManager');
-        $events->attach($listener);
+        $listener->attach($events);
         $events->setIdentifiers($resourceIdentifiers);
 
         $resource = new Resource();

--- a/src/Factory/ResourceControllerFactory.php
+++ b/src/Factory/ResourceControllerFactory.php
@@ -8,10 +8,11 @@
 
 namespace PhlyRestfully\Factory;
 
+use Interop\Container\ContainerInterface;
 use PhlyRestfully\Resource;
 use PhlyRestfully\ResourceController;
 use Zend\EventManager\ListenerAggregateInterface;
-use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -25,15 +26,13 @@ class ResourceControllerFactory implements AbstractFactoryInterface
     /**
      * Determine if we can create a service with name
      *
-     * @param \Zend\ServiceManager\AbstractPluginManager $controllers
-     * @param string                  $name
      * @param string                  $requestedName
      *
      * @return bool
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $controllers, $name, $requestedName)
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
-        $services = $controllers->getServiceLocator();
+        $services = $container;
 
         if (!$services->has('config') || !$services->has('EventManager')) {
             // Config and EventManager are required
@@ -75,17 +74,15 @@ class ResourceControllerFactory implements AbstractFactoryInterface
     /**
      * Create service with name
      *
-     * @param \Zend\ServiceManager\AbstractPluginManager $controllers
-     * @param string                  $name
      * @param string                  $requestedName
      *
      * @return ResourceController
      *
      * @throws ServiceNotCreatedException if listener specified is not a ListenerAggregate
      */
-    public function createServiceWithName(ServiceLocatorInterface $controllers, $name, $requestedName)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $services = $controllers->getServiceLocator();
+        $services = $container;
         /** @var array $config */
         $config   = $services->get('config');
         $config   = $config['phlyrestfully']['resources'][$requestedName];

--- a/src/Link.php
+++ b/src/Link.php
@@ -205,7 +205,7 @@ class Link
             throw new Exception\InvalidArgumentException(sprintf(
                 'Received invalid URL: %s',
                 $e->getMessage()
-            ), $e->getCode(), $e);
+            ), (int) $e->getCode(), $e);
         }
 
         if (!$uri->isValid()) {

--- a/src/LinkCollectionAwareInterface.php
+++ b/src/LinkCollectionAwareInterface.php
@@ -10,6 +10,13 @@ namespace PhlyRestfully;
 
 interface LinkCollectionAwareInterface
 {
+    /**
+     * @return self
+     */
     public function setLinks(LinkCollection $links);
+
+    /**
+     * @return LinkCollection
+     */
     public function getLinks();
 }

--- a/src/Listener/ApiProblemListener.php
+++ b/src/Listener/ApiProblemListener.php
@@ -34,7 +34,7 @@ class ApiProblemListener implements ListenerAggregateInterface
     protected static $acceptFilter = 'application/hal+json,application/api-problem+json,application/json';
 
     /**
-     * @var \Zend\Stdlib\CallbackHandler[]
+     * @var callable[]
      */
     protected $listeners = [];
 
@@ -67,9 +67,8 @@ class ApiProblemListener implements ListenerAggregateInterface
     public function detach(EventManagerInterface $events)
     {
         foreach ($this->listeners as $index => $listener) {
-            if ($events->detach($listener)) {
-                unset($this->listeners[$index]);
-            }
+            $events->detach($listener);
+            unset($this->listeners[$index]);
         }
     }
 

--- a/src/Listener/ApiProblemListener.php
+++ b/src/Listener/ApiProblemListener.php
@@ -55,6 +55,7 @@ class ApiProblemListener implements ListenerAggregateInterface
     /**
      * @param EventManagerInterface $events
      * @param int $priority
+     * @return void
      */
     public function attach(EventManagerInterface $events, $priority = 1)
     {
@@ -63,6 +64,7 @@ class ApiProblemListener implements ListenerAggregateInterface
 
     /**
      * @param EventManagerInterface $events
+     * @return void
      */
     public function detach(EventManagerInterface $events)
     {

--- a/src/Listener/ResourceParametersListener.php
+++ b/src/Listener/ResourceParametersListener.php
@@ -17,12 +17,12 @@ use Zend\Mvc\MvcEvent;
 class ResourceParametersListener implements ListenerAggregateInterface
 {
     /**
-     * @var \Zend\Stdlib\CallbackHandler[]
+     * @var callable[]
      */
     protected $listeners = [];
 
     /**
-     * @var \Zend\Stdlib\CallbackHandler[]
+     * @var callable[]
      */
     protected $sharedListeners = [];
 
@@ -41,9 +41,8 @@ class ResourceParametersListener implements ListenerAggregateInterface
     public function detach(EventManagerInterface $events)
     {
         foreach ($this->listeners as $index => $listener) {
-            if ($events->detach($listener)) {
-                unset($this->listeners[$index]);
-            }
+            $events->detach($listener);
+            unset($this->listeners[$index]);
         }
     }
 
@@ -67,14 +66,14 @@ class ResourceParametersListener implements ListenerAggregateInterface
         // Vary detachment based on zend-eventmanager version.
         $detach = method_exists($events, 'attachAggregate')
             ? /**
-             * @param \Zend\Stdlib\CallbackHandler $listener
+             * @param callable $listener
              * @return bool
              */
             function ($listener) use ($events) {
                 return $events->detach(ResourceController::class, $listener);
             }
         : /**
-         * @param \Zend\Stdlib\CallbackHandler $listener
+         * @param callable $listener
          * @return bool
          */
         function ($listener) use ($events) {

--- a/src/Listener/ResourceParametersListener.php
+++ b/src/Listener/ResourceParametersListener.php
@@ -29,6 +29,7 @@ class ResourceParametersListener implements ListenerAggregateInterface
     /**
      * @param EventManagerInterface $events
      * @param int $priority
+     * @return void
      */
     public function attach(EventManagerInterface $events, $priority = 1)
     {
@@ -37,6 +38,7 @@ class ResourceParametersListener implements ListenerAggregateInterface
 
     /**
      * @param EventManagerInterface $events
+     * @return void
      */
     public function detach(EventManagerInterface $events)
     {

--- a/src/Module.php
+++ b/src/Module.php
@@ -263,7 +263,7 @@ class Module
                 $eventManager = $e->getApplication()->getEventManager();
                 /** @var Listener\ApiProblemListener $apiProblemListener */
                 $apiProblemListener = $services->get(Listener\ApiProblemListener::class);
-                $eventManager->attach($apiProblemListener);
+                $apiProblemListener->attach($eventManager);
             },
             300
         );
@@ -299,6 +299,6 @@ class Module
 
         // register at high priority, to "beat" normal json strategy registered
         // via view manager
-        $events->attach($restfulJsonStrategy, 200);
+        $restfulJsonStrategy->attach($events, 200);
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -89,7 +89,7 @@ class Module
                         /** @var HydratorPluginManager $hydrators */
                         $hydrators = $services->get('HydratorManager');
                     } else {
-                        $hydrators = new HydratorPluginManager();
+                        $hydrators = new HydratorPluginManager($services);
                     }
 
                     $map = [];
@@ -121,6 +121,7 @@ class Module
                     }
 
                     $renderer = new View\RestfulJsonRenderer();
+                    $renderer->setServiceManager($services);
                     $renderer->setHelperPluginManager($helpers);
                     $renderer->setDisplayExceptions($displayExceptions);
 
@@ -152,11 +153,10 @@ class Module
         return ['factories' => [
             'HalLinks' =>
             /**
-             * @param \Zend\ServiceManager\ServiceLocatorAwareInterface $plugins
+             * @param \Zend\ServiceManager\ServiceLocatorInterface $services
              * @return Plugin\HalLinks
              */
-            function ($plugins) {
-                $services = $plugins->getServiceLocator();
+            function ($services) {
                 /** @var \Zend\View\HelperPluginManager $helpers */
                 $helpers  = $services->get('ViewHelperManager');
                 /** @var Plugin\HalLinks $halLinks */
@@ -177,16 +177,18 @@ class Module
         return ['factories' => [
             'HalLinks' =>
             /**
-             * @param \Zend\ServiceManager\AbstractPluginManager $helpers
+             * @param \Zend\ServiceManager\ServiceManager|\Zend\View\HelperPluginManager $helpers
              * @return Plugin\HalLinks
              */
             function ($helpers) {
+                $services = $helpers;
+                $helpers = $services->get('ViewHelperManager');
+
                 /** @var \Zend\View\Helper\ServerUrl $serverUrlHelper */
                 $serverUrlHelper = $helpers->get('ServerUrl');
                 /** @var \Zend\View\Helper\Url $urlHelper */
                 $urlHelper       = $helpers->get('Url');
 
-                $services        = $helpers->getServiceLocator();
                 /** @var array $config */
                 $config          = $services->get('config');
                 /** @var MetadataMap $metadataMap */

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -189,9 +189,15 @@ class Resource implements ResourceInterface
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, ['data' => $data]);
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
             return $data;
@@ -227,27 +233,40 @@ class Resource implements ResourceInterface
         }
 
         $original = $data;
-        array_walk($data, function ($value, $key) use (&$data) {
-            if (is_array($value)) {
-                $data[$key] = new ArrayObject($value);
-                return;
-            }
+        array_walk(
+            $data,
+            /**
+             * @param array|string $value
+             * @param string|int $key
+             */
+            function ($value, $key) use (&$data): void {
+                if (is_array($value)) {
+                    $data[$key] = new ArrayObject($value);
+                    return;
+                }
 
-            if (!is_object($value)) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Data provided to patchList must contain only arrays or objects; received "%s"',
-                    gettype($value)
-                ));
+                if (!is_object($value)) {
+                    throw new Exception\InvalidArgumentException(sprintf(
+                        'Data provided to patchList must contain only arrays or objects; received "%s"',
+                        gettype($value)
+                    ));
+                }
             }
-        });
+        );
 
         $data     = new ArrayObject($data);
         /** @var \Zend\EventManager\EventManager $events */
         $events   = $this->getEventManager();
         $event    = $this->prepareEvent(__FUNCTION__, ['data' => $data]);
-        $results  = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results  = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last     = $results->last();
         if (!is_array($last) && !is_object($last)) {
             return $original;
@@ -287,9 +306,15 @@ class Resource implements ResourceInterface
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, compact('id', 'data'));
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
             return $data;
@@ -322,25 +347,38 @@ class Resource implements ResourceInterface
                 gettype($data)
             ));
         }
-        array_walk($data, function ($value, $key) use (&$data) {
-            if (is_array($value)) {
-                $data[$key] = (object) $value;
-                return;
-            }
+        array_walk(
+            $data,
+            /**
+             * @param array|object $value
+             * @param string|int $key
+             */
+            function ($value, $key) use (&$data): void {
+                if (is_array($value)) {
+                    $data[$key] = (object) $value;
+                    return;
+                }
 
-            if (!is_object($value)) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Data provided to replaceList must contain only arrays or objects; received "%s"',
-                    gettype($value)
-                ));
+                if (!is_object($value)) {
+                    throw new Exception\InvalidArgumentException(sprintf(
+                        'Data provided to replaceList must contain only arrays or objects; received "%s"',
+                        gettype($value)
+                    ));
+                }
             }
-        });
+        );
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, ['data' => $data]);
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
             return $data;
@@ -381,9 +419,15 @@ class Resource implements ResourceInterface
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, compact('id', 'data'));
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
             return $data;
@@ -406,9 +450,15 @@ class Resource implements ResourceInterface
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, ['id' => $id]);
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_bool($last) && !$last instanceof ApiProblem) {
             return false;
@@ -419,7 +469,7 @@ class Resource implements ResourceInterface
     /**
      * Delete an existing collection of records
      *
-     * @param  null|array $data
+     * @param  null|array|Traversable $data
      * @return bool|ApiProblem
      */
     public function deleteList($data = null)
@@ -436,9 +486,15 @@ class Resource implements ResourceInterface
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, ['data' => $data]);
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_bool($last) && !$last instanceof ApiProblem) {
             return false;
@@ -462,9 +518,15 @@ class Resource implements ResourceInterface
         /** @var \Zend\EventManager\EventManager $events */
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, ['id' => $id]);
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
             return false;
@@ -483,7 +545,9 @@ class Resource implements ResourceInterface
      * which will allow performing paginated sets, and thus allow the view
      * layer to select the current page based on the query string or route.
      *
-     * @return array|Traversable|HalCollection|ApiProblem
+     * @return ApiProblem|HalCollection|iterable
+     *
+     * @psalm-return ApiProblem|HalCollection|iterable<array-key|mixed, mixed>
      */
     public function fetchAll()
     {
@@ -491,9 +555,15 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $params  = func_get_args();
         $event   = $this->prepareEvent(__FUNCTION__, $params);
-        $results = $events->triggerEventUntil(function ($result) {
-            return $result instanceof ApiProblem;
-        }, $event);
+        $results = $events->triggerEventUntil(
+            /**
+             * @param object $result
+             */
+            function ($result): bool {
+                return $result instanceof ApiProblem;
+            },
+            $event
+        );
         $last    = $results->last();
         if (!is_array($last)
             && !$last instanceof HalCollection
@@ -512,7 +582,7 @@ class Resource implements ResourceInterface
      * to a resource method, and passes them to the `prepareArgs` method of the
      * event manager.
      *
-     * @param  array $args
+     * @param  string $name
      * @return ResourceEvent
      */
     protected function prepareEvent($name, array $args)
@@ -530,7 +600,7 @@ class Resource implements ResourceInterface
      * by listeners and retrieved.
      *
      * @param  array $args
-     * @return ArrayObject
+     * @return ArrayObject|array
      */
     protected function prepareEventParams(array $args)
     {

--- a/src/ResourceController.php
+++ b/src/ResourceController.php
@@ -331,7 +331,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $resource = $this->resource->create($data);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
             return new ApiProblem($code, $e);
         }
 
@@ -378,7 +378,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $collection = $this->resource->patchList($data);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
             return new ApiProblem($code, $e);
         }
 
@@ -422,7 +422,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $result = $this->resource->delete($id);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
 
             return new ApiProblem($code, $e);
         }
@@ -444,6 +444,7 @@ class ResourceController extends AbstractRestfulController
 
     /**
      * @param array $data
+     * @return \Zend\Http\Response|ApiProblem
      */
     public function deleteList($data = [])
     {
@@ -457,7 +458,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $result = $this->resource->deleteList();
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
 
             return new ApiProblem($code, $e);
         }
@@ -495,7 +496,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $resource = $this->resource->fetch($id);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
 
             return new ApiProblem($code, $e);
         }
@@ -534,7 +535,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $collection = $this->resource->fetchAll();
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
 
             return new ApiProblem($code, $e);
         }
@@ -639,7 +640,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $resource = $this->resource->patch($id, $data);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
             return new ApiProblem($code, $e);
         }
 
@@ -680,7 +681,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $resource = $this->resource->update($id, $data);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
             return new ApiProblem($code, $e);
         }
 
@@ -713,7 +714,7 @@ class ResourceController extends AbstractRestfulController
         try {
             $collection = $this->resource->replaceList($data);
         } catch (\Exception $e) {
-            $code = $e->getCode() ?: 500;
+            $code = (int) $e->getCode() ?: 500;
             return new ApiProblem($code, $e);
         }
 

--- a/src/View/RestfulJsonStrategy.php
+++ b/src/View/RestfulJsonStrategy.php
@@ -66,6 +66,7 @@ class RestfulJsonStrategy extends JsonStrategy
      * type based on the detection that occurred during renderer selection.
      *
      * @param  ViewEvent $e
+     * @return void
      */
     public function injectResponse(ViewEvent $e)
     {

--- a/test/ChildResourcesIntegrationTest.php
+++ b/test/ChildResourcesIntegrationTest.php
@@ -236,7 +236,7 @@ class ChildResourcesIntegrationTest extends TestCase
 
         $this->assertObjectHasAttribute('_embedded', $test);
         $this->assertObjectHasAttribute('child', $test->_embedded);
-        $this->assertInternalType('array', $test->_embedded->child);
+        $this->assertIsArray($test->_embedded->child);
 
         foreach ($test->_embedded->child as $child) {
             $this->assertObjectHasAttribute('_links', $child);
@@ -336,7 +336,7 @@ class ChildResourcesIntegrationTest extends TestCase
 
         $this->assertObjectHasAttribute('_embedded', $test);
         $this->assertObjectHasAttribute('child', $test->_embedded);
-        $this->assertInternalType('array', $test->_embedded->child);
+        $this->assertIsArray($test->_embedded->child);
 
         foreach ($test->_embedded->child as $child) {
             $this->assertObjectHasAttribute('_links', $child);
@@ -447,7 +447,7 @@ class ChildResourcesIntegrationTest extends TestCase
 
         $this->assertObjectHasAttribute('_embedded', $test);
         $this->assertObjectHasAttribute('children', $test->_embedded);
-        $this->assertInternalType('array', $test->_embedded->children);
+        $this->assertIsArray($test->_embedded->children);
 
         foreach ($test->_embedded->children as $child) {
             $this->assertObjectHasAttribute('_links', $child);

--- a/test/ChildResourcesIntegrationTest.php
+++ b/test/ChildResourcesIntegrationTest.php
@@ -19,9 +19,11 @@ use PhlyRestfully\View\RestfulJsonRenderer;
 use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
 use Zend\Http\Request;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 use Zend\View\Helper\Url as UrlHelper;
@@ -51,17 +53,22 @@ class ChildResourcesIntegrationTest extends TestCase
         $serverUrlHelper->setScheme('http');
         $serverUrlHelper->setHost('localhost.localdomain');
 
-        $linksHelper = new HalLinks();
+        $this->serviceManager = new ServiceManager();
+
+        $hydratorPluginManager = new HydratorPluginManager($this->serviceManager);
+        $this->serviceManager->setService('HydratorManager', $hydratorPluginManager);
+
+        $linksHelper = new HalLinks($hydratorPluginManager);
         $linksHelper->setUrlHelper($urlHelper);
         $linksHelper->setServerUrlHelper($serverUrlHelper);
 
-        $this->helpers = $helpers = new HelperPluginManager();
-        $helpers->setService('url', $urlHelper);
-        $helpers->setService('serverUrl', $serverUrlHelper);
-        $helpers->setService('halLinks', $linksHelper);
+        $this->helpers = $helpers = new HelperPluginManager($this->serviceManager);
+        $helpers->setService('Url', $urlHelper);
+        $helpers->setService('ServerUrl', $serverUrlHelper);
+        $helpers->setService('HalLinks', $linksHelper);
 
-        $this->plugins = $plugins = new ControllerPluginManager();
-        $plugins->setService('halLinks', $linksHelper);
+        $this->plugins = $plugins = new ControllerPluginManager($this->serviceManager);
+        $plugins->setService('HalLinks', $linksHelper);
     }
 
     public function setupRenderer()
@@ -70,6 +77,7 @@ class ChildResourcesIntegrationTest extends TestCase
             $this->setupHelpers();
         }
         $this->renderer = $renderer = new RestfulJsonRenderer();
+        $renderer->setServiceManager($this->serviceManager);
         $renderer->setHelperPluginManager($this->helpers);
     }
 
@@ -169,7 +177,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         $parent = $this->setUpParentResource();
         $model  = new RestfulJsonModel();
@@ -195,7 +203,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent/child', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         $child = $this->setUpChildResource('luke', 'Luke Skywalker');
         $model = new RestfulJsonModel();
@@ -221,7 +229,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent/child', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         $collection = $this->setUpChildCollection();
         $model = new RestfulJsonModel();
@@ -276,7 +284,7 @@ class ChildResourcesIntegrationTest extends TestCase
         ];
         $this->router = $router = new TreeRouteStack();
         $router->addRoutes($routes);
-        $this->helpers->get('url')->setRouter($router);
+        $this->helpers->get('Url')->setRouter($router);
     }
 
     public function testChildResourceObjectIdentiferMapping()
@@ -293,7 +301,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent/child', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         $child = $this->setUpChildResource('luke', 'Luke Skywalker');
         $model = new RestfulJsonModel();
@@ -321,7 +329,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent/child', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         $collection = $this->setUpChildCollection();
         $model = new RestfulJsonModel();
@@ -378,7 +386,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent/child', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         // Ensure we matched an identifier!
         $id = $m->invoke($controller, $matches, $request);
@@ -429,7 +437,7 @@ class ChildResourcesIntegrationTest extends TestCase
         $this->assertEquals('parent/child', $matches->getMatchedRouteName());
 
         // Emulate url helper factory and inject route matches
-        $this->helpers->get('url')->setRouteMatch($matches);
+        $this->helpers->get('Url')->setRouteMatch($matches);
 
         $result = $controller->getList();
         $this->assertInstanceOf(HalCollection::class, $result);

--- a/test/CollectionIntegrationTest.php
+++ b/test/CollectionIntegrationTest.php
@@ -139,7 +139,7 @@ class CollectionIntegrationTest extends TestCase
 
         $resource = new Resource();
         $events   = $resource->getEventManager();
-        $events->attach($this->listeners);
+        $this->listeners->attach($events);
 
         $controller = $this->controller = new ResourceController('Api\ResourceController');
         $controller->setResource($resource);

--- a/test/CollectionIntegrationTest.php
+++ b/test/CollectionIntegrationTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase as TestCase;
 use Zend\EventManager\SharedEventManager;
 use Zend\Http\PhpEnvironment\Request;
 use Zend\Http\PhpEnvironment\Response;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\Mvc\Controller\ControllerManager;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\Mvc\MvcEvent;
@@ -33,7 +34,6 @@ use Zend\Uri;
 use Zend\View\HelperPluginManager;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 use Zend\View\Helper\Url as UrlHelper;
-use Zend\ServiceManager\Config;
 
 /**
  * @subpackage UnitTest
@@ -48,9 +48,6 @@ class CollectionIntegrationTest extends TestCase
 
     public function setUpHelpers()
     {
-        if (isset($this->helpers)) {
-            return;
-        }
         $this->setupRouter();
 
         $urlHelper = new UrlHelper();
@@ -60,29 +57,34 @@ class CollectionIntegrationTest extends TestCase
         $serverUrlHelper->setScheme('http');
         $serverUrlHelper->setHost('localhost.localdomain');
 
-        $this->linksHelper = $linksHelper = new HalLinks();
+        $this->serviceManager = $this->getServiceManager();
+
+        $hydratorPluginManager = new HydratorPluginManager($this->serviceManager);
+        $this->serviceManager->setService('HydratorManager', $hydratorPluginManager);
+
+        $this->linksHelper = $linksHelper = new HalLinks($hydratorPluginManager);
         $linksHelper->setUrlHelper($urlHelper);
         $linksHelper->setServerUrlHelper($serverUrlHelper);
 
-        $this->helpers = $helpers = new HelperPluginManager();
-        $helpers->setService('url', $urlHelper);
-        $helpers->setService('serverUrl', $serverUrlHelper);
-        $helpers->setService('halLinks', $linksHelper);
+        $plugins = $this->serviceManager->get('ControllerPluginManager');
+        $plugins->setService('HalLinks', $linksHelper);
+
+        $this->helpers = $helpers = new HelperPluginManager($this->serviceManager);
+        $helpers->setService('Url', $urlHelper);
+        $helpers->setService('ServerUrl', $serverUrlHelper);
+        $helpers->setService('HalLinks', $linksHelper);
     }
 
     public function setUpRenderer()
     {
         $this->setupHelpers();
         $this->renderer = $renderer = new RestfulJsonRenderer();
+        $renderer->setServiceManager($this->serviceManager);
         $renderer->setHelperPluginManager($this->helpers);
     }
 
     public function setUpRouter()
     {
-        if (isset($this->router)) {
-            return;
-        }
-
         $this->setUpRequest();
 
         $routes = [
@@ -124,10 +126,6 @@ class CollectionIntegrationTest extends TestCase
 
     public function setUpListeners()
     {
-        if (isset($this->listeners)) {
-            return;
-        }
-
         $this->listeners = new TestAsset\CollectionIntegrationListener();
         $this->listeners->setCollection($this->setUpCollection());
     }
@@ -148,17 +146,13 @@ class CollectionIntegrationTest extends TestCase
         $controller->setRoute('resource');
         $controller->setEvent($this->getEvent());
 
-        $plugins = new ControllerPluginManager();
+        $plugins = new ControllerPluginManager($this->serviceManager);
         $plugins->setService('HalLinks', $this->linksHelper);
         $controller->setPluginManager($plugins);
     }
 
     public function setUpRequest()
     {
-        if (isset($this->request)) {
-            return;
-        }
-
         $uri = Uri\UriFactory::factory('http://localhost.localdomain/api/resource?query=foo&page=2');
 
         $request = $this->request = new Request();
@@ -174,9 +168,6 @@ class CollectionIntegrationTest extends TestCase
 
     public function setUpResponse()
     {
-        if (isset($this->response)) {
-            return;
-        }
         $this->response = new Response();
     }
 
@@ -189,46 +180,6 @@ class CollectionIntegrationTest extends TestCase
         $event->setRouter($this->router);
         $event->setRouteMatch($this->matches);
         return $event;
-    }
-
-    public function testCollectionLinksIncludeFullQueryString()
-    {
-        $this->controller->getEventManager()->attach('getList.post', function ($e) {
-            $request    = $e->getTarget()->getRequest();
-            $query = $request->getQuery('query', false);
-            if (!$query) {
-                return;
-            }
-
-            $collection = $e->getParam('collection');
-            $collection->setCollectionRouteOptions([
-                'query' => [
-                    'query' => $query,
-                ],
-            ]);
-        });
-        $result = $this->controller->dispatch($this->request, $this->response);
-        $this->assertInstanceOf(RestfulJsonModel::class, $result);
-
-        $json = $this->renderer->render($result);
-        $payload = json_decode($json, true);
-        $this->assertArrayHasKey('_links', $payload);
-        $links = $payload['_links'];
-        foreach ($links as $name => $link) {
-            $this->assertArrayHasKey('href', $link);
-            if ('first' !== $name) {
-                $this->assertContains(
-                    'page=',
-                    $link['href'],
-                    "Link $name ('{$link['href']}') is missing page query param"
-                );
-            }
-            $this->assertContains(
-                'query=foo',
-                $link['href'],
-                "Link $name ('{$link['href']}') is missing query query param"
-            );
-        }
     }
 
     public function getServiceManager()
@@ -261,24 +212,60 @@ class CollectionIntegrationTest extends TestCase
         $services->setShared('EventManager', false);
 
         $collection = $this->setUpCollection();
-        $services->addInitializer(function ($instance, $services) use ($collection) {
-            if (!$instance instanceof TestAsset\CollectionIntegrationListener) {
-                return;
-            }
-            $instance->setCollection($collection);
+        $services->addDelegator(TestAsset\CollectionIntegrationListener::class, function ($container, $name, $callback) use ($collection) {
+            $listener = $callback();
+            $listener->setCollection($collection);
+            return $listener;
         });
-
-        $controllers->setServiceLocator($services);
-
-        $plugins = $services->get('ControllerPluginManager');
-        $plugins->setService('HalLinks', $this->linksHelper);
 
         return $services;
     }
 
+    public function testCollectionLinksIncludeFullQueryString()
+    {
+        $this->controller->getEventManager()->attach('getList.post', function ($e) {
+            $request    = $e->getTarget()->getRequest();
+            $query = $request->getQuery('query', false);
+            if (!$query) {
+                return;
+            }
+
+            $collection = $e->getParam('collection');
+            $collection->setCollectionRouteOptions([
+                'query' => [
+                    'query' => $query,
+                ],
+            ]);
+        });
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertInstanceOf(RestfulJsonModel::class, $result);
+
+        $json = $this->renderer->render($result);
+        $payload = json_decode($json, true);
+
+        $this->assertArrayHasKey('_links', $payload);
+        $links = $payload['_links'];
+        foreach ($links as $name => $link) {
+            $this->assertArrayHasKey('href', $link);
+            if ('first' !== $name) {
+                $this->assertContains(
+                    'page=',
+                    $link['href'],
+                    "Link $name ('{$link['href']}') is missing page query param"
+                );
+            }
+            $this->assertContains(
+                'query=foo',
+                $link['href'],
+                "Link $name ('{$link['href']}') is missing query query param"
+            );
+        }
+    }
+
     public function testFactoryEnabledListenerCreatesQueryStringWhitelist()
     {
-        $services = $this->getServiceManager();
+        $services = $this->serviceManager;
+
         $controller = $services->get('ControllerManager')->get('Api\ResourceController');
         $controller->setEvent($this->getEvent());
 
@@ -287,6 +274,7 @@ class CollectionIntegrationTest extends TestCase
 
         $json = $this->renderer->render($result);
         $payload = json_decode($json, true);
+
         $this->assertArrayHasKey('_links', $payload);
         $links = $payload['_links'];
         foreach ($links as $name => $link) {

--- a/test/Factory/ResourceControllerFactoryTest.php
+++ b/test/Factory/ResourceControllerFactoryTest.php
@@ -28,7 +28,6 @@ class ResourceControllerFactoryTest extends TestCase
         $this->factory     = $factory     = new ResourceControllerFactory();
 
         $controllers->addAbstractFactory($factory);
-        $controllers->setServiceLocator($services);
 
         $services->setService(ServiceLocatorInterface::class, $services);
         $services->setService('config', $this->getConfig());
@@ -65,10 +64,10 @@ class ResourceControllerFactoryTest extends TestCase
 
     public function testWillInstantiateAlternateResourceControllerWhenSpecified()
     {
-        $config = $this->services->get('Config');
+        $config = $this->services->get('config');
         $config['phlyrestfully']['resources']['ApiController']['controller_class'] = TestAsset\CustomController::class;
         $this->services->setAllowOverride(true);
-        $this->services->setService('Config', $config);
+        $this->services->setService('config', $config);
         $controller = $this->controllers->get('ApiController');
         $this->assertInstanceOf(TestAsset\CustomController::class, $controller);
     }

--- a/test/Factory/TestAsset/Listener.php
+++ b/test/Factory/TestAsset/Listener.php
@@ -13,7 +13,7 @@ use Zend\EventManager\ListenerAggregateInterface;
 
 class Listener implements ListenerAggregateInterface
 {
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
     }
 

--- a/test/LinkCollectionTest.php
+++ b/test/LinkCollectionTest.php
@@ -42,7 +42,7 @@ class LinkCollectionTest extends TestCase
 
         $this->assertTrue($this->links->has('order'));
         $orders = $this->links->get('order');
-        $this->assertInternalType('array', $orders);
+        $this->assertIsArray($orders);
         $this->assertContains($order1, $orders);
         $this->assertContains($order2, $orders);
     }

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -58,7 +58,7 @@ class ModuleTest extends TestCase
         $app->expects($this->once())
             ->method('getMvcEvent')
             ->will($this->returnValue($event));
-        $services->setService('application', $app);
+        $services->setService('Application', $app);
 
         $helpers = $services->get('ViewHelperManager');
         $helpersConfig = new Config($config['view_helpers']);
@@ -82,9 +82,9 @@ class ModuleTest extends TestCase
         ];
 
         $services = $this->setupServiceManager();
-        $config   = $services->get('Config');
+        $config   = $services->get('config');
         $services->setAllowOverride(true);
-        $services->setService('Config', ArrayUtils::merge($config, $options));
+        $services->setService('config', ArrayUtils::merge($config, $options));
 
         $helpers = $services->get('ViewHelperManager');
         $plugin  = $helpers->get('HalLinks');
@@ -107,9 +107,9 @@ class ModuleTest extends TestCase
         ];
 
         $services = $this->setupServiceManager();
-        $config   = $services->get('Config');
+        $config   = $services->get('config');
         $services->setAllowOverride(true);
-        $services->setService('Config', ArrayUtils::merge($config, $options));
+        $services->setService('config', ArrayUtils::merge($config, $options));
 
         $helpers = $services->get('ViewHelperManager');
         $plugin  = $helpers->get('HalLinks');

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -121,7 +121,7 @@ class ModuleTest extends TestCase
 
         $hydrators   = $plugin->getHydratorManager();
 
-        $this->assertInternalType('array', $hydratorMap);
+        $this->assertIsArray($hydratorMap);
 
         foreach ($options['phlyrestfully']['renderer']['hydrators'] as $class => $serviceName) {
             $key = strtolower($class);

--- a/test/Plugin/HalLinksTest.php
+++ b/test/Plugin/HalLinksTest.php
@@ -17,13 +17,13 @@ use PhlyRestfully\ResourceController;
 use PHPUnit\Framework\TestCase as TestCase;
 use Zend\Http\Request;
 use Zend\Hydrator;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\Mvc\Router\SimpleRouteStack;
 use Zend\Mvc\Router\Http\Segment;
 use Zend\Mvc\MvcEvent;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Uri\Http;
-use Zend\Uri\Uri;
 use Zend\View\Helper\Url as UrlHelper;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 
@@ -98,6 +98,10 @@ class HalLinksTest extends TestCase
             ->method('getEvent')
             ->will($this->returnValue($event));
 
+        $this->serviceManager = new ServiceManager();
+
+        $this->hydratorPluginManager = new HydratorPluginManager($this->serviceManager);
+
         $this->urlHelper = $urlHelper = new UrlHelper();
         $urlHelper->setRouter($router);
 
@@ -105,7 +109,7 @@ class HalLinksTest extends TestCase
         $serverUrlHelper->setScheme('http');
         $serverUrlHelper->setHost('localhost.localdomain');
 
-        $this->plugin = $plugin = new HalLinks();
+        $this->plugin = $plugin = new HalLinks($this->hydratorPluginManager);
         $plugin->setController($controller);
         $plugin->setUrlHelper($urlHelper);
         $plugin->setServerUrlHelper($serverUrlHelper);
@@ -229,7 +233,7 @@ class HalLinksTest extends TestCase
                 'route'           => 'hostname/embedded_custom',
                 'identifier_name' => 'custom_id',
             ],
-        ]);
+        ], $this->hydratorPluginManager);
 
         $this->plugin->setMetadataMap($metadata);
 
@@ -267,7 +271,7 @@ class HalLinksTest extends TestCase
                 'route'          => 'hostname/contacts',
                 'resource_route' => 'hostname/embedded',
             ],
-        ]);
+        ], $this->hydratorPluginManager);
 
         $this->plugin->setMetadataMap($metadata);
 
@@ -321,7 +325,7 @@ class HalLinksTest extends TestCase
                 'hydrator' => Hydrator\ObjectProperty::class,
                 'route'    => 'hostname/resource',
             ],
-        ]);
+        ], $this->hydratorPluginManager);
 
         $this->plugin->setMetadataMap($metadata);
 
@@ -475,7 +479,7 @@ class HalLinksTest extends TestCase
                 'hydrator' => 'ArraySerializable',
                 'route'    => 'hostname/resource',
             ],
-        ]);
+        ], $this->hydratorPluginManager);
 
         $collection = new HalCollection([$resource]);
         $collection->setCollectionName('resource');
@@ -523,7 +527,7 @@ class HalLinksTest extends TestCase
                     ],
                 ],
             ],
-        ]);
+        ], $this->hydratorPluginManager);
 
         $this->plugin->setMetadataMap($metadata);
         $resource = $this->plugin->createResourceFromMetadata(
@@ -569,7 +573,7 @@ class HalLinksTest extends TestCase
                     ],
                 ],
             ],
-        ]);
+        ], $this->hydratorPluginManager);
 
         $this->plugin->setMetadataMap($metadata);
 

--- a/test/Plugin/HalLinksTest.php
+++ b/test/Plugin/HalLinksTest.php
@@ -113,16 +113,16 @@ class HalLinksTest extends TestCase
 
     public function assertRelationalLinkContains($match, $relation, $resource)
     {
-        $this->assertInternalType('array', $resource);
+        $this->assertIsArray($resource);
         $this->assertArrayHasKey('_links', $resource);
         $links = $resource['_links'];
-        $this->assertInternalType('array', $links);
+        $this->assertIsArray($links);
         $this->assertArrayHasKey($relation, $links);
         $link = $links[$relation];
-        $this->assertInternalType('array', $link);
+        $this->assertIsArray($link);
         $this->assertArrayHasKey('href', $link);
         $href = $link['href'];
-        $this->assertInternalType('string', $href);
+        $this->assertIsString($href);
         $this->assertContains($match, $href);
     }
 
@@ -154,17 +154,17 @@ class HalLinksTest extends TestCase
         $resource->getLinks()->add($self)->add($docs);
         $links = $this->plugin->fromResource($resource);
 
-        $this->assertInternalType('array', $links);
+        $this->assertIsArray($links);
         $this->assertArrayHasKey('self', $links, var_export($links, 1));
         $this->assertArrayHasKey('describedby', $links, var_export($links, 1));
 
         $selfLink = $links['self'];
-        $this->assertInternalType('array', $selfLink);
+        $this->assertIsArray($selfLink);
         $this->assertArrayHasKey('href', $selfLink);
         $this->assertEquals('http://localhost.localdomain/resource/123', $selfLink['href']);
 
         $docsLink = $links['describedby'];
-        $this->assertInternalType('array', $docsLink);
+        $this->assertIsArray($docsLink);
         $this->assertArrayHasKey('href', $docsLink);
         $this->assertEquals('http://localhost.localdomain/help', $docsLink['href']);
     }
@@ -197,10 +197,10 @@ class HalLinksTest extends TestCase
         $embed = $rendered['_embedded'];
         $this->assertArrayHasKey('contacts', $embed);
         $contacts = $embed['contacts'];
-        $this->assertInternalType('array', $contacts);
-        $this->assertEquals(3, count($contacts));
+        $this->assertIsArray($contacts);
+        $this->assertCount(3, $contacts);
         foreach ($contacts as $contact) {
-            $this->assertInternalType('array', $contact);
+            $this->assertIsArray($contact);
             $this->assertRelationalLinkContains('/contacts/', 'self', $contact);
         }
     }
@@ -238,16 +238,16 @@ class HalLinksTest extends TestCase
 
         $this->assertArrayHasKey('_embedded', $rendered);
         $embed = $rendered['_embedded'];
-        $this->assertEquals(2, count($embed));
+        $this->assertCount(2, $embed);
         $this->assertArrayHasKey('first_child', $embed);
         $this->assertArrayHasKey('second_child', $embed);
 
         $first = $embed['first_child'];
-        $this->assertInternalType('array', $first);
+        $this->assertIsArray($first);
         $this->assertRelationalLinkContains('/embedded/bar', 'self', $first);
 
         $second = $embed['second_child'];
-        $this->assertInternalType('array', $second);
+        $this->assertIsArray($second);
         $this->assertRelationalLinkContains('/embedded_custom/baz', 'self', $second);
     }
 
@@ -290,10 +290,10 @@ class HalLinksTest extends TestCase
         $embed = $rendered['_embedded'];
         $this->assertArrayHasKey('contacts', $embed);
         $contacts = $embed['contacts'];
-        $this->assertInternalType('array', $contacts);
-        $this->assertEquals(3, count($contacts));
+        $this->assertIsArray($contacts);
+        $this->assertCount(3, $contacts);
         foreach ($contacts as $contact) {
-            $this->assertInternalType('array', $contact);
+            $this->assertIsArray($contact);
             $this->assertArrayHasKey('id', $contact);
             $this->assertRelationalLinkContains('/embedded/' . $contact['id'], 'self', $contact);
         }
@@ -339,18 +339,18 @@ class HalLinksTest extends TestCase
         $embed = $rendered['_embedded'];
         $this->assertArrayHasKey('resources', $embed);
         $resources = $embed['resources'];
-        $this->assertInternalType('array', $resources);
-        $this->assertEquals(1, count($resources));
+        $this->assertIsArray($resources);
+        $this->assertCount(1, $resources);
 
         $resource = array_shift($resources);
-        $this->assertInternalType('array', $resource);
+        $this->assertIsArray($resource);
         $this->assertArrayHasKey('_embedded', $resource);
-        $this->assertInternalType('array', $resource['_embedded']);
+        $this->assertIsArray($resource['_embedded']);
         $this->assertArrayHasKey('first_child', $resource['_embedded']);
-        $this->assertInternalType('array', $resource['_embedded']['first_child']);
+        $this->assertIsArray($resource['_embedded']['first_child']);
 
         foreach ($resource['_embedded']['first_child'] as $contact) {
-            $this->assertInternalType('array', $contact);
+            $this->assertIsArray($contact);
             $this->assertArrayHasKey('id', $contact);
             $this->assertRelationalLinkContains('/embedded/' . $contact['id'], 'self', $contact);
         }
@@ -397,7 +397,7 @@ class HalLinksTest extends TestCase
 
         $this->assertRelationalLinkContains('/users/user', 'self', $rendered);
         $this->assertArrayHasKey('_embedded', $rendered);
-        $this->assertInternalType('array', $rendered['_embedded']);
+        $this->assertIsArray($rendered['_embedded']);
         $this->assertArrayHasKey('contact', $rendered['_embedded']);
         $contact = $rendered['_embedded']['contact'];
         $this->assertRelationalLinkContains('/contacts/foo', 'self', $contact);
@@ -427,11 +427,11 @@ class HalLinksTest extends TestCase
 
         $this->assertRelationalLinkContains('/users', 'self', $rendered);
         $this->assertArrayHasKey('_embedded', $rendered);
-        $this->assertInternalType('array', $rendered['_embedded']);
+        $this->assertIsArray($rendered['_embedded']);
         $this->assertArrayHasKey('users', $rendered['_embedded']);
 
         $users = $rendered['_embedded']['users'];
-        $this->assertInternalType('array', $users);
+        $this->assertIsArray($users);
         $user = array_shift($users);
 
         $this->assertRelationalLinkContains('/users/foo', 'self', $user);
@@ -455,11 +455,11 @@ class HalLinksTest extends TestCase
 
         $this->assertRelationalLinkContains('/embedded_custom', 'self', $rendered);
         $this->assertArrayHasKey('_embedded', $rendered);
-        $this->assertInternalType('array', $rendered['_embedded']);
+        $this->assertIsArray($rendered['_embedded']);
         $this->assertArrayHasKey('embedded_custom', $rendered['_embedded']);
 
         $embeddedCustoms = $rendered['_embedded']['embedded_custom'];
-        $this->assertInternalType('array', $embeddedCustoms);
+        $this->assertIsArray($embeddedCustoms);
         $embeddedCustom = array_shift($embeddedCustoms);
 
         $this->assertRelationalLinkContains('/embedded_custom/foo', 'self', $embeddedCustom);
@@ -485,15 +485,15 @@ class HalLinksTest extends TestCase
 
         $test = $this->plugin->renderCollection($collection);
 
-        $this->assertInternalType('array', $test);
+        $this->assertIsArray($test);
         $this->assertArrayHasKey('_embedded', $test);
-        $this->assertInternalType('array', $test['_embedded']);
+        $this->assertIsArray($test['_embedded']);
         $this->assertArrayHasKey('resource', $test['_embedded']);
-        $this->assertInternalType('array', $test['_embedded']['resource']);
+        $this->assertIsArray($test['_embedded']['resource']);
 
         $resources = $test['_embedded']['resource'];
         $testResource = array_shift($resources);
-        $this->assertInternalType('array', $testResource);
+        $this->assertIsArray($testResource);
         $this->assertArrayHasKey('id', $testResource);
         $this->assertArrayHasKey('name', $testResource);
     }

--- a/test/ResourceControllerTest.php
+++ b/test/ResourceControllerTest.php
@@ -22,6 +22,7 @@ use stdClass;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
 use Zend\Http;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\Http\Segment;
@@ -29,6 +30,7 @@ use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\SimpleRouteStack;
 use Zend\Paginator\Adapter\ArrayAdapter as ArrayPaginator;
 use Zend\Paginator\Paginator;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\Parameters;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 use Zend\View\Helper\Url as UrlHelper;
@@ -52,7 +54,9 @@ class ResourceControllerTest extends TestCase
         $controller->setEvent($event);
         $controller->setRoute('resource');
 
-        $pluginManager = new PluginManager();
+        $serviceManager = new ServiceManager();
+
+        $pluginManager = new PluginManager($serviceManager);
         $controller->setPluginManager($pluginManager);
 
         $urlHelper = new UrlHelper();
@@ -62,7 +66,9 @@ class ResourceControllerTest extends TestCase
         $serverUrlHelper->setScheme('http');
         $serverUrlHelper->setHost('localhost.localdomain');
 
-        $linksHelper = new Plugin\HalLinks();
+        $hydratorPluginManager = new HydratorPluginManager($serviceManager);
+
+        $linksHelper = new Plugin\HalLinks($hydratorPluginManager);
         $linksHelper->setUrlHelper($urlHelper);
         $linksHelper->setServerUrlHelper($serverUrlHelper);
 

--- a/test/ResourceControllerTest.php
+++ b/test/ResourceControllerTest.php
@@ -442,7 +442,8 @@ class ResourceControllerTest extends TestCase
     public function testOnDispatchRaisesDomainExceptionOnMissingResource()
     {
         $controller = new ResourceController();
-        $this->expectException(Exception\DomainException::class, 'ResourceInterface');
+        $this->expectException(Exception\DomainException::class);
+        $this->expectExceptionMessage('ResourceInterface');
         $controller->onDispatch($this->event);
     }
 
@@ -450,7 +451,8 @@ class ResourceControllerTest extends TestCase
     {
         $controller = new ResourceController();
         $controller->setResource($this->resource);
-        $this->expectException(Exception\DomainException::class, 'route');
+        $this->expectException(Exception\DomainException::class);
+        $this->expectExceptionMessage('route');
         $controller->onDispatch($this->event);
     }
 
@@ -1027,10 +1029,11 @@ class ResourceControllerTest extends TestCase
     }
 
     /**
-     * @expectedException \PhlyRestfully\Exception\DomainException
      */
     public function testGetResourceThrowsExceptionOnMissingResource()
     {
+        $this->expectException(\PhlyRestfully\Exception\DomainException::class);
+
         $controller = new ResourceController();
         $controller->getResource();
     }

--- a/test/ResourceControllerTest.php
+++ b/test/ResourceControllerTest.php
@@ -529,9 +529,9 @@ class ResourceControllerTest extends TestCase
     public function testPassingIdentifierToConstructorAllowsListeningOnThatIdentifier()
     {
         $controller   = new ResourceController('MyNamespace\Controller\Foo');
-        $events       = new EventManager();
         $sharedEvents = new SharedEventManager();
-        $events->setSharedManager($sharedEvents);
+        $events       = new EventManager($sharedEvents);
+
         $controller->setEventManager($events);
 
         $test = new stdClass;

--- a/test/ResourceTest.php
+++ b/test/ResourceTest.php
@@ -322,7 +322,8 @@ class ResourceTest extends TestCase
      */
     public function testDeleteListRaisesInvalidArgumentExceptionForInvalidData($data)
     {
-        $this->expectException(Exception\InvalidArgumentException::class, '::deleteList');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('::deleteList');
         $this->resource->deleteList($data);
     }
 

--- a/test/TestAsset/CollectionIntegrationListener.php
+++ b/test/TestAsset/CollectionIntegrationListener.php
@@ -17,7 +17,7 @@ class CollectionIntegrationListener implements ListenerAggregateInterface
 
     protected $listeners = [];
 
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach('fetchAll', [$this, 'onFetchAll']);
     }

--- a/test/TestAsset/CollectionIntegrationListener.php
+++ b/test/TestAsset/CollectionIntegrationListener.php
@@ -25,9 +25,8 @@ class CollectionIntegrationListener implements ListenerAggregateInterface
     public function detach(EventManagerInterface $events)
     {
         foreach ($this->listeners as $index => $listener) {
-            if ($events->detach($listener)) {
-                unset($this->listeners[$index]);
-            }
+            $events->detach($listener);
+            unset($this->listeners[$index]);
         }
     }
 

--- a/test/View/RestfulJsonRendererTest.php
+++ b/test/View/RestfulJsonRendererTest.php
@@ -19,10 +19,12 @@ use PhlyRestfully\View\RestfulJsonRenderer;
 use PhlyRestfullyTest\TestAsset;
 use PHPUnit\Framework\TestCase as TestCase;
 use ReflectionObject;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\Mvc\Router\Http\Segment;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Paginator\Adapter\ArrayAdapter;
 use Zend\Paginator\Paginator;
+use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator;
 use Zend\View\HelperPluginManager;
 use Zend\View\Model\JsonModel;
@@ -36,6 +38,7 @@ class RestfulJsonRendererTest extends TestCase
     public function setUp()
     {
         $this->renderer = new RestfulJsonRenderer();
+        $this->serviceManager = new ServiceManager();
     }
 
     public function assertIsHalResource($resource)
@@ -126,13 +129,15 @@ class RestfulJsonRendererTest extends TestCase
         $this->resourceRoute = new Segment('/resource[/[:id]]');
         $this->router->addRoute('resource', $this->resourceRoute);
 
-        $this->helpers = $helpers  = new HelperPluginManager();
+        $hydratorPluginManager = new HydratorPluginManager($this->serviceManager);
+
+        $this->helpers = $helpers  = new HelperPluginManager($this->serviceManager);
         $serverUrl = $helpers->get('ServerUrl');
         $url       = $helpers->get('url');
         $url->setRouter($router);
         $serverUrl->setScheme('http');
         $serverUrl->setHost('localhost.localdomain');
-        $halLinks  = new HalLinks();
+        $halLinks  = new HalLinks($hydratorPluginManager);
         $halLinks->setServerUrlHelper($serverUrl);
         $halLinks->setUrlHelper($url);
         $helpers->setService('HalLinks', $halLinks);

--- a/test/View/RestfulJsonRendererTest.php
+++ b/test/View/RestfulJsonRendererTest.php
@@ -23,7 +23,7 @@ use Zend\Mvc\Router\Http\Segment;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Paginator\Adapter\ArrayAdapter;
 use Zend\Paginator\Paginator;
-use Zend\Stdlib\Hydrator;
+use Zend\Hydrator;
 use Zend\View\HelperPluginManager;
 use Zend\View\Model\JsonModel;
 use Zend\View\Model\ViewModel;

--- a/test/View/RestfulJsonRendererTest.php
+++ b/test/View/RestfulJsonRendererTest.php
@@ -262,8 +262,8 @@ class RestfulJsonRendererTest extends TestCase
         $this->assertObjectHasAttribute('_embedded', $test);
         $this->assertInstanceof('stdClass', $test->_embedded);
         $this->assertObjectHasAttribute('items', $test->_embedded);
-        $this->assertInternalType('array', $test->_embedded->items);
-        $this->assertEquals(100, count($test->_embedded->items));
+        $this->assertIsArray($test->_embedded->items);
+        $this->assertCount(100, $test->_embedded->items);
 
         foreach ($test->_embedded->items as $key => $item) {
             $id = $key + 1;
@@ -314,8 +314,8 @@ class RestfulJsonRendererTest extends TestCase
         $this->assertObjectHasAttribute('_embedded', $test);
         $this->assertInstanceof('stdClass', $test->_embedded);
         $this->assertObjectHasAttribute('items', $test->_embedded);
-        $this->assertInternalType('array', $test->_embedded->items);
-        $this->assertEquals(5, count($test->_embedded->items));
+        $this->assertIsArray($test->_embedded->items);
+        $this->assertCount(5, $test->_embedded->items);
 
         foreach ($test->_embedded->items as $key => $item) {
             $id = $key + 11;
@@ -651,8 +651,8 @@ class RestfulJsonRendererTest extends TestCase
         $this->assertObjectHasAttribute('_embedded', $test);
         $this->assertInstanceof('stdClass', $test->_embedded);
         $this->assertObjectHasAttribute('items', $test->_embedded);
-        $this->assertInternalType('array', $test->_embedded->items);
-        $this->assertEquals(100, count($test->_embedded->items));
+        $this->assertIsArray($test->_embedded->items);
+        $this->assertCount(100, $test->_embedded->items);
 
         foreach ($test->_embedded->items as $key => $item) {
             $id = $key + 1;


### PR DESCRIPTION
Tests were not passing on php nightly because of an older version of zend-stdlib throwing warnings.

The issue has since been fixed in zend-stdlib, but only in 3.2.1+.  Upgrading to that version of zend-stdlib requires bumping some other dependencies and dealing with incompatibilities with those updates.